### PR TITLE
Set user/group of hello.txt to www-data

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -19,6 +19,9 @@
     - name: Create website root
       file: path=/srv/website state=directory
 
+    - name: Set hello.txt owner/group to www-data
+      file: path=/srv/website/hello.txt owner=www-data group=www-data
+
     - name: Add a nice page
       copy: content="Hello world" dest=/srv/website/hello.txt
 

--- a/test_nginx.py
+++ b/test_nginx.py
@@ -17,8 +17,8 @@ def test_website_root(File):
     f = File("/srv/website/hello.txt")
     assert f.exists
     assert f.content == "Hello world"
-    assert f.user == "root"
-    assert f.group == "root"
+    assert f.user == "www-data"
+    assert f.group == "www-data"
     assert f.mode == 644
 
 


### PR DESCRIPTION
This patch break the full deployment because the file `hello.txt` doesn't exists. But it work on an already provisioned image (production).

Travis build: https://travis-ci.org/philpep/test-driven-infrastructure-example/builds/76951079
Jenkins build: https://jenkins.philpep.org/job/test-driven-infrastructure-example-pr/16/

``` text
TASK: [Set hello.txt owner/group to www-data] ********************************* 
failed: [default] => {"failed": true, "path": "/srv/website/hello.txt", "state": "absent"}
msg: file (/srv/website/hello.txt) is absent, cannot continue
changed: [production]
```
