### PR TITLE
Rename hello.txt to hello_world.txt

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -20,7 +20,7 @@
       file: path=/srv/website state=directory
 
     - name: Add a nice page
-      copy: content="Hello world" dest=/srv/website/hello.txt
+      copy: content="Hello world" dest=/srv/website/hello_world.txt
 
   handlers:
     - name: nginx restart

--- a/test_nginx.py
+++ b/test_nginx.py
@@ -14,7 +14,7 @@ def test_service(Service):
 
 
 def test_website_root(File):
-    f = File("/srv/website/hello.txt")
+    f = File("/srv/website/hello_world.txt")
     assert f.exists
     assert f.content == "Hello world"
     assert f.user == "root"
@@ -24,5 +24,5 @@ def test_website_root(File):
 
 def test_website(Command):
     output = Command.check_output(
-        "curl -H 'Host: website' http://127.0.0.1/hello.txt")
+        "curl -H 'Host: website' http://127.0.0.1/hello_world.txt")
     assert output == "Hello world"


### PR DESCRIPTION
This test break because we don't remove the `hello.txt` resulting to a different state on a full or on a half provisioned system:

Travis build: https://travis-ci.org/philpep/test-driven-infrastructure-example/builds/76951185
Jenkins build: https://jenkins.philpep.org/job/test-driven-infrastructure-example-pr/15/

``` text
def test_same_website_root():
        tree = {}
        for name in ("default", "production"):
            conn = testinfra.get_backend(
                name, connection="paramiko", ssh_config=".vagrant-ssh-config")
            Command = conn.get_module("Command")
            tree[name] = Command.check_output("tree /srv/website")

>       assert tree["default"] == tree["production"]
E       assert '/srv/website...ories, 1 file' == '/srv/website\n...ries, 2 files'
E           /srv/website
E         + |-- hello.txt
E           `-- hello_world.txt
E           
E         - 0 directories, 1 file
E         ?                ^
E         + 0 directories, 2 files
E         ?                ^     +

test_same_state.py:12: AssertionError
```
