### PR TITLE
Upgrade to nginx 1.8

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -2,6 +2,9 @@
 - hosts: all
   gather_facts: no
   tasks:
+    - name: Add ppa:nginx/stable repo
+      apt_repository: repo='ppa:nginx/stable'
+
     - name: Install nginx, curl and tree
       apt: pkg={{ item }} state=present
       with_items:

--- a/test_nginx.py
+++ b/test_nginx.py
@@ -4,7 +4,7 @@ testinfra_hosts = ["default", "production"]
 def test_package(Package):
     nginx = Package("nginx")
     assert nginx.is_installed
-    assert nginx.version.startswith("1.4")
+    assert nginx.version.startswith("1.8")
 
 
 def test_service(Service):


### PR DESCRIPTION
This patch work on a new server but not a already provisioned because nginx is already installed and not upgraded.

Travis build: https://travis-ci.org/philpep/test-driven-infrastructure-example/builds/76951116
Jenkins build: https://jenkins.philpep.org/job/test-driven-infrastructure-example-pr/14/

``` text
    def test_package(Package):
        nginx = Package("nginx")
        assert nginx.is_installed
>       assert nginx.version.startswith("1.8")
E       assert <built-in method startswith of unicode object at 0x7fd13eee2fc0>('1.8')
E        +  where <built-in method startswith of unicode object at 0x7fd13eee2fc0> = '1.4.6-1ubuntu3.3'.startswith
E        +    where '1.4.6-1ubuntu3.3' = <package nginx>.version

test_nginx.py:7: AssertionError
```
